### PR TITLE
style: use tabular-nums for text ticker wrapper

### DIFF
--- a/src/app/docs/components/text/page.mdx
+++ b/src/app/docs/components/text/page.mdx
@@ -65,7 +65,7 @@ import TextTicker from 'path-to-text-ticker-component'
 
 export const TextTicker = () => {
   return (
-    <div className="text-2xl font-semibold tracking-tight">
+    <div className="text-2xl font-semibold tabular-nums tracking-tight">
       <TextTicker value={1000} /> // use direction param for "up" or "down"
     </div>
   )

--- a/src/components/PreviewCode/Text.tsx
+++ b/src/components/PreviewCode/Text.tsx
@@ -2,7 +2,7 @@ import Counter from '../Counter'
 
 export const TextTicker = () => {
   return (
-    <div className="text-4xl font-semibold tracking-tight text-red-500">
+    <div className="text-4xl font-semibold tabular-nums tracking-tight text-red-500">
       <Counter value={1000} />
     </div>
   )


### PR DESCRIPTION
Since the text ticker component is using an animated counter, there's a slight content shift happening due to numbers being different size. We fix it by adding `tabular-nums`.

You can see more at :

- [https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric)
- [https://twitter.com/jh3yy/status/1715409590320288041](https://twitter.com/jh3yy/status/1715409590320288041)