### PR TITLE
fix : pricing page code tab responsive issue

### DIFF
--- a/src/app/docs/components/pricing/page.tsx
+++ b/src/app/docs/components/pricing/page.tsx
@@ -8,8 +8,8 @@ export const metadata = {
 
 const PricingMDX = () => {
   return (
-    <div className="my-12 flex w-full items-center justify-center">
-      <div className="flex max-w-5xl flex-col items-start justify-center">
+    <div className="my-12 flex flex-col max-w-5xl mx-auto ">
+      <div className="flex-auto">
         <div className="text-2xl font-bold">Pricing</div>
         <PreviewCodeTabs
           previewContent={


### PR DESCRIPTION
Fix mobile responsiveness issue in pricing page code tab

This pull request addresses an issue where the code tab in the pricing page was not rendering correctly on mobile devices.

#### Changes
- Adjusted CSS to prevent code preview content from overflowing the page on smaller screens.

Attached screenshots:

- Before: [Link](https://github.com/Ansub/SyntaxUI/assets/44539538/4113c3b6-362e-4ea1-9eeb-f07c18c1e724)

- After: [Link](https://github.com/Ansub/SyntaxUI/assets/44539538/d48003ce-b5d5-4035-ba24-aedbfb511fb8)



