### PR TITLE
fix: duplicate html and body tags

### DIFF
--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -18,12 +18,8 @@ export default async function RootLayout({
   let allSections = Object.fromEntries(allSectionsEntries)
 
   return (
-    <html lang="en" className="h-full" suppressHydrationWarning>
-      <body className="flex min-h-full bg-white antialiased dark:bg-zinc-900">
-        <div className="w-full">
-          <Layout allSections={allSections}>{children}</Layout>
-        </div>
-      </body>
-    </html>
+    <div className="flex min-h-full w-full bg-white antialiased dark:bg-zinc-900">
+      <Layout allSections={allSections}>{children}</Layout>
+    </div>
   )
 }


### PR DESCRIPTION
fix: #107 

Error was cause from having `html` and `body` components in both `src/app/layout.tsx` and `src/app/docs/layout.tsx`.

Layouts are nested which means that `src/app/layout.tsx` is applied then `src/app/docs/layout.tsx` is placed inside of if which meant that we essentially had `html > body > html > body` which isn't allowed.

To fix this,  I combined the `html`, `body`, and `div` components in `src/app/docs/layout.tsx` into a single `div` component.