### PR TITLE
Add check for `button` click in `onBlur` handler

### DIFF
--- a/src/app/docs/components/input/page.mdx
+++ b/src/app/docs/components/input/page.mdx
@@ -82,8 +82,8 @@ const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 setInputValue(event.target.value)
 }
 // Adds the keyword when the input loses focus, if there's a keyword to add
-const handleBlur = () => {
-if (inputValue.trim() !== '') {
+const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+if (inputValue.trim() !== '' && event.relatedTarget?.tagName !== 'BUTTON') {
 const newKeywords = [...keywords, inputValue.trim()]
 setKeywords(newKeywords)
 onKeywordsChange(newKeywords)
@@ -121,7 +121,7 @@ return (
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       onPaste={handlePaste}
-      onBlur={handleBlur}
+      onBlur={(e) => handleBlur(e)}
       className="my-1 flex-1 text-sm outline-none"
       placeholder="Type keyword and press Enter..."
     />

--- a/src/showcase/components/input/TagInput.tsx
+++ b/src/showcase/components/input/TagInput.tsx
@@ -52,8 +52,8 @@ const TagInput: React.FC = () => {
     setInputValue(event.target.value)
   }
   // Adds the keyword when the input loses focus, if there's a keyword to add
-  const handleBlur = () => {
-    if (inputValue.trim() !== '') {
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (inputValue.trim() !== '' && event.relatedTarget?.tagName !== 'BUTTON') {
       const newKeywords = [...keywords, inputValue.trim()]
       setKeywords(newKeywords)
       onKeywordsChange(newKeywords)
@@ -90,7 +90,7 @@ const TagInput: React.FC = () => {
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          onBlur={handleBlur}
+          onBlur={(e) => handleBlur(e)}
           className="my-1 flex-1 text-sm outline-none"
           placeholder="Type keyword and press Enter..."
         />


### PR DESCRIPTION
## Description

Added check for `button` click in `onBlur` handler.
### intuition
if the user clicks on `button`, we assume that the user wants to do some other task, so we don't update the `keywords` state.

## Related Issue

Fixes #115  

## Proposed Changes

- `TagInput.tsx`

## Screenshots

https://github.com/Ansub/SyntaxUI/assets/114096753/8aa67a6b-5317-47ff-be1f-84ffe9b27f9a

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)
