### PR TITLE
moved ClipboardIcon from Code.tsx to CopyButton.tsx

### DIFF
--- a/src/components/code/Code.tsx
+++ b/src/components/code/Code.tsx
@@ -99,19 +99,3 @@ export function RawCode({
 }) {
   return <Code code={rawCode} language={rawLang} />
 }
-
-export function ClipboardIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
-  return (
-    <svg viewBox="0 0 20 20" aria-hidden="true" {...props}>
-      <path
-        strokeWidth="0"
-        d="M5.5 13.5v-5a2 2 0 0 1 2-2l.447-.894A2 2 0 0 1 9.737 4.5h.527a2 2 0 0 1 1.789 1.106l.447.894a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2Z"
-      />
-      <path
-        fill="none"
-        strokeLinejoin="round"
-        d="M12.5 6.5a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2m5 0-.447-.894a2 2 0 0 0-1.79-1.106h-.527a2 2 0 0 0-1.789 1.106L7.5 6.5m5 0-1 1h-3l-1-1"
-      />
-    </svg>
-  )
-}

--- a/src/components/code/CopyButton.tsx
+++ b/src/components/code/CopyButton.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
-import { ClipboardIcon } from './Code'
 
 export function CopyButton({ value }: { value: string }) {
   let [copyCount, setCopyCount] = useState(0)
@@ -51,5 +50,21 @@ export function CopyButton({ value }: { value: string }) {
         Copied!
       </span>
     </button>
+  )
+}
+
+function ClipboardIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true" {...props}>
+      <path
+        strokeWidth="0"
+        d="M5.5 13.5v-5a2 2 0 0 1 2-2l.447-.894A2 2 0 0 1 9.737 4.5h.527a2 2 0 0 1 1.789 1.106l.447.894a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2Z"
+      />
+      <path
+        fill="none"
+        strokeLinejoin="round"
+        d="M12.5 6.5a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2m5 0-.447-.894a2 2 0 0 0-1.79-1.106h-.527a2 2 0 0 0-1.789 1.106L7.5 6.5m5 0-1 1h-3l-1-1"
+      />
+    </svg>
   )
 }


### PR DESCRIPTION
## Description

Moved the ClipboardIcon component from Code.tsx to CopyButton.tsx

## Related Issue

Fixes #126 

## Proposed Changes

- Moved ClipboardIcon from Code.tsx to CopyButton.tsx

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)
