### PR TITLE
bug: Remove unnecessary backslash in markdown code snippet

### DIFF
--- a/src/app/docs/components/input/page.mdx
+++ b/src/app/docs/components/input/page.mdx
@@ -93,7 +93,7 @@ setInputValue('')
 
 // Removes a keyword from the list
 const removeKeyword = (indexToRemove: number) => {
-const newKeywords = keywords.filter((\_, index) => index !== indexToRemove)
+const newKeywords = keywords.filter((_, index) => index !== indexToRemove)
 setKeywords(newKeywords)
 onKeywordsChange(newKeywords)
 }


### PR DESCRIPTION
Related to #124

Removes the unnecessary backslash from the markdown code snippet in `src/app/docs/components/input/page.mdx`.