### PR TITLE
fix: empty keyword on enter.

### DIFF
--- a/src/app/docs/components/input/page.mdx
+++ b/src/app/docs/components/input/page.mdx
@@ -45,8 +45,8 @@ const [inputValue, setInputValue] = useState<string>('')
 // Handles adding new keyword on Enter or comma press, and keyword removal on Backspace
 const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
 if (
-event.key === 'Enter' ||
-(event.key === ',' && inputValue.trim() !== '')
+(event.key === 'Enter' ||
+event.key === ',') && inputValue.trim() !== ''
 ) {
 event.preventDefault()
 const newKeywords = [...keywords, inputValue.trim()]

--- a/src/showcase/components/input/TagInput.tsx
+++ b/src/showcase/components/input/TagInput.tsx
@@ -15,8 +15,8 @@ const TagInput: React.FC = () => {
   // Handles adding new keyword on Enter or comma press, and keyword removal on Backspace
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (
-      event.key === 'Enter' ||
-      (event.key === ',' && inputValue.trim() !== '')
+      (event.key === 'Enter' || event.key === ',') &&
+      inputValue.trim() !== ''
     ) {
       event.preventDefault()
       const newKeywords = [...keywords, inputValue.trim()]


### PR DESCRIPTION
## Description

When pressing enter do not and empty keyword when the `input value` is empty.

## Related Issue

Fixes #125 

## Proposed Changes

- `TagInput.tsx`
- `docs/components/input/page.mdx`

## Screenshots


https://github.com/Ansub/SyntaxUI/assets/114096753/a887dbd0-b7bf-4c64-b7ca-64abfbd2c265



## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
