### PR TITLE
fix: shiki -> react-syntax-highlighter 

### DIFF
--- a/src/components/code/Code.tsx
+++ b/src/components/code/Code.tsx
@@ -1,10 +1,13 @@
 'use client'
 
-import codeToHtml from '@/lib/codeToHtml'
-import { Suspense, useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { CodeGroupContext } from './CodeGroup'
 import { cn } from '@/lib/utils'
 import { CopyButton } from './CopyButton'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { dark } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import theme from './theme'
+import { gruvboxDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 
 /**
  * This is a code block component that accepts `code: string` and a `language: string`.
@@ -32,17 +35,11 @@ export default function Code({
     return (rawCode ?? '').trim().split('\n').length === 1 && !inCodeGroup
   }, [inCodeGroup])
 
-  const [code, setCode] = useState<string | undefined>(undefined)
-  useEffect(() => {
-    const loadCode = async () => {
-      const html = await codeToHtml(
-        (rawCode ?? '').trim(),
-        rawLang ? rawLang.replaceAll('language-', '') : '',
-      )
-      setCode(html)
-    }
-    loadCode()
-  }, [rawCode, rawLang])
+  const lang = useMemo(
+    () => (rawLang ? rawLang.replace('language-', '') : 'plaintext'),
+    [rawLang],
+  )
+  const code = useMemo(() => rawCode.trim(), [rawCode])
 
   if (inline) {
     return (
@@ -59,23 +56,9 @@ export default function Code({
         inCodeGroup ? 'rounded-b-lg rounded-t-none' : 'rounded-lg',
       )}
     >
-      {code === undefined ? (
-        <div className="p-4 text-white">Loading...</div>
-      ) : (
-        <>
-          <div
-            className="text-wrap p-4"
-            dangerouslySetInnerHTML={{ __html: code }}
-            style={{
-              scrollbarColor: ' #d4d4d4 transparent',
-            }}
-          ></div>
-          <CopyButton
-            value={rawCode}
-            // className="text-foreground hover:bg-muted hover:text-foreground absolute right-2 top-2 h-7 w-7 opacity-100 [&_svg]:size-3.5"
-          />
-        </>
-      )}
+      <SyntaxHighlighter language={lang} wrapLines wrapLongLines style={theme}>
+        {code}
+      </SyntaxHighlighter>
     </div>
   )
 }

--- a/src/components/code/Code.tsx
+++ b/src/components/code/Code.tsx
@@ -56,6 +56,7 @@ export default function Code({
         inCodeGroup ? 'rounded-b-lg rounded-t-none' : 'rounded-lg',
       )}
     >
+      <CopyButton value={code} className="z-10 border-none" />
       <SyntaxHighlighter language={lang} wrapLines wrapLongLines style={theme}>
         {code}
       </SyntaxHighlighter>

--- a/src/components/code/ComponentPreview.tsx
+++ b/src/components/code/ComponentPreview.tsx
@@ -116,7 +116,6 @@ export function ComponentPreview({
       )}
       {selectedTab === 'code' && (
         <div className="relative w-full">
-          <CopyButton value={codeString} className="top-5" />
           <Code language="tsx" code={codeString} />
         </div>
       )}

--- a/src/components/code/ComponentPreview.tsx
+++ b/src/components/code/ComponentPreview.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { RawCode } from '@/components/code/Code'
+import Code, { RawCode } from '@/components/code/Code'
 import { Icons } from '@/components/icons/Icons'
 import AnimatedTabs from '@/components/reusable/AnimatedTabs'
 import { cn } from '@/lib/utils'
@@ -117,9 +117,7 @@ export function ComponentPreview({
       {selectedTab === 'code' && (
         <div className="relative w-full">
           <CopyButton value={codeString} className="top-5" />
-          <SyntaxHighlighter language="jsx" wrapLines wrapLongLines>
-            {codeString}
-          </SyntaxHighlighter>
+          <Code language="tsx" code={codeString} />
         </div>
       )}
     </div>

--- a/src/components/code/theme.ts
+++ b/src/components/code/theme.ts
@@ -1,0 +1,67 @@
+import { CSSProperties } from 'react'
+
+/*
+
+We can implement more tokens from Prism's token list here:
+
+https://prismjs.com/tokens.html
+
+*/
+
+const prismTheme: { [key: string]: CSSProperties } = {
+  /* Overall styles */
+  'code[class*="language-"]': {
+    backgroundColor: 'transparent',
+  },
+  'pre[class*="language-"]': {
+    padding: '1em',
+  },
+  /* Token styles */
+  text: {
+    color: 'var(--prism-color-text)',
+  },
+  constant: {
+    color: 'var(--prism-token-constant)',
+  },
+  string: {
+    color: 'var(--prism-token-string)',
+  },
+  comment: {
+    color: 'var(--prism-token-comment)',
+  },
+  keyword: {
+    color: 'var(--prism-token-keyword)',
+  },
+  parameter: {
+    color: 'var(--prism-token-parameter)',
+  },
+  function: {
+    color: 'var(--prism-token-function)',
+  },
+  'string-expression': {
+    color: 'var(--prism-token-string-expression)',
+  },
+  punctuation: {
+    color: 'var(--prism-token-punctuation)',
+  },
+  property: {
+    color: 'var(--prism-token-property)',
+  },
+  tag: {
+    color: 'var(--prism-token-tag)',
+  },
+  'attr-name': {
+    color: 'var(--prism-token-attr-name)',
+  },
+  'attr-value': {
+    color: 'var(--prism-token-attr-value)',
+  },
+  'class-name': {
+    color: 'var(--prism-token-class-name)',
+  },
+  'property-access': {
+    color: 'var(--prism-token-property-access)',
+  },
+}
+
+export default prismTheme

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -4,15 +4,21 @@
 
 @layer base {
   :root {
-    --shiki-color-text: theme('colors.white');
-    --shiki-token-constant: theme('colors.red.300');
-    --shiki-token-string: theme('colors.red.300');
-    --shiki-token-comment: theme('colors.zinc.500');
-    --shiki-token-keyword: theme('colors.sky.300');
-    --shiki-token-parameter: theme('colors.pink.300');
-    --shiki-token-function: theme('colors.violet.300');
-    --shiki-token-string-expression: theme('colors.red.300');
-    --shiki-token-punctuation: theme('colors.zinc.200');
+    --prism-color-text: theme('colors.white');
+    --prism-token-constant: theme('colors.red.300');
+    --prism-token-string: theme('colors.red.300');
+    --prism-token-comment: theme('colors.zinc.500');
+    --prism-token-keyword: theme('colors.sky.300');
+    --prism-token-parameter: theme('colors.pink.300');
+    --prism-token-function: theme('colors.violet.300');
+    --prism-token-property: theme('colors.red.100');
+    --prism-token-string-expression: theme('colors.red.300');
+    --prism-token-punctuation: theme('colors.zinc.200');
+    --prism-token-tag: theme('colors.green.200');
+    --prism-token-attr-name: theme('colors.violet.200');
+    --prism-token-attr-value: theme('colors.red.300');
+    --prism-token-class-name: theme('colors.green.200');
+    --prism-token-property-access: theme('colors.green.200');
   }
 
   [inert] ::-webkit-scrollbar {


### PR DESCRIPTION
## Description

using `react-syntax-highlighter` in Code now / ComponentPreview references Code again / customizable prism theme

## Related Issue

Fixes #135 

## Proposed Changes

- Using `react-syntax-highlighter` instead of `codeToHtml` in `src/components/code/Code.tsx`
- Using `Code` instead of `react-syntax-highlighter` in `src/components/code/ComponentPreview.tsx` to only reference `react-syntax-highlighter` in one place
- `react-syntax-highlighter` uses a theme defined in `src/components/code/theme.ts`
  - theme is based on css variables in `src/styles/tailwind.css`
  - available tokens are defined at https://prismjs.com/tokens.html

## Screenshots

<img width="1076" alt="Screenshot 2024-05-03 at 10 57 04 AM" src="https://github.com/Ansub/SyntaxUI/assets/16091805/a4bd5271-419f-4b44-812a-44ec0d70ef15">

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

