### PR TITLE
fix: Tailwind/Framer Motion Icon Vertical Alignment

### DIFF
--- a/src/components/code/ComponentPreview.tsx
+++ b/src/components/code/ComponentPreview.tsx
@@ -90,11 +90,30 @@ export function ComponentPreview({
         <div className="flex items-center gap-2">
           <h2 className="text-md m-0 font-medium text-gray-800">{name}</h2>
           <div className="flex items-center justify-center gap-x-2">
-            <div>
+            <TooltipProvider>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger>
+                  <TailwindCSS />
+                </TooltipTrigger>
+                <TooltipContent className="m-0 p-0 text-sm">
+                  <p className="m-0 p-1">
+                    This component requires{' '}
+                    <a
+                      target="_blank"
+                      rel="noreferrer"
+                      href="https://www.framer.com/motion/"
+                    >
+                      Tailwind CSS
+                    </a>
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            {usingFramer && (
               <TooltipProvider>
                 <Tooltip delayDuration={0}>
                   <TooltipTrigger>
-                    <TailwindCSS />
+                    <FramerLogo />
                   </TooltipTrigger>
                   <TooltipContent className="m-0 p-0 text-sm">
                     <p className="m-0 p-1">
@@ -104,35 +123,12 @@ export function ComponentPreview({
                         rel="noreferrer"
                         href="https://www.framer.com/motion/"
                       >
-                        Tailwind CSS
+                        Framer Motion
                       </a>
                     </p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
-            </div>
-            {usingFramer && (
-              <div>
-                <TooltipProvider>
-                  <Tooltip delayDuration={0}>
-                    <TooltipTrigger>
-                      <FramerLogo />
-                    </TooltipTrigger>
-                    <TooltipContent className="m-0 p-0 text-sm">
-                      <p className="m-0 p-1">
-                        This component requires{' '}
-                        <a
-                          target="_blank"
-                          rel="noreferrer"
-                          href="https://www.framer.com/motion/"
-                        >
-                          Framer Motion
-                        </a>
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Description

The Tailwind and Framer Motion icon's were aligned to the top instead of the center.

## Related Issue

Fixes #150 

## Proposed Changes

- I removed the bare `<div>`s from around the `TooltipeProviders` in `src/components/code/ComponentPreview.tsx`

## Screenshots

Before:
<img width="571" alt="Screenshot 2024-05-05 at 9 50 57 AM" src="https://github.com/Ansub/SyntaxUI/assets/16091805/01d66fd2-8701-4762-a19f-95a32b449eb1">

After: 
<img width="571" alt="Screenshot 2024-05-05 at 9 50 33 AM" src="https://github.com/Ansub/SyntaxUI/assets/16091805/a702fed7-182f-4a0e-8f24-a2a8567e4582">

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

