### PR TITLE
fix: collapse/expand hover state

### DIFF
--- a/src/components/code/CodeGroup.tsx
+++ b/src/components/code/CodeGroup.tsx
@@ -51,12 +51,12 @@ export default function CodeGroup({
         )}
         <div ref={codeRef}>{children}</div>
         {/* {canExpand && ( */}
-        <Button
-          className="w-xs absolute bottom-0 left-0 right-0 block rounded-2xl bg-transparent p-0 text-sm font-medium text-white"
+        <a
+          className="w-xs absolute bottom-0 left-2 right-0 block rounded-2xl bg-transparent p-0 text-sm font-medium text-white no-underline cursor-pointer"
           onClick={() => setMinimized(!minimized)}
         >
           {minimized ? 'Expand' : 'Collapse'}
-        </Button>
+        </a>
         {/* )} */}
       </div>
     </CodeGroupContext.Provider>

--- a/src/components/code/CodeGroup.tsx
+++ b/src/components/code/CodeGroup.tsx
@@ -52,7 +52,7 @@ export default function CodeGroup({
         <div ref={codeRef}>{children}</div>
         {/* {canExpand && ( */}
         <a
-          className="w-xs absolute bottom-0 left-0 right-0 block rounded-2xl bg-transparent p-0 text-sm text-center font-medium text-white no-underline cursor-pointer"
+          className="w-full absolute bottom-0 left-0 right-0 block rounded-2xl bg-transparent p-0 text-sm font-medium text-white no-underline cursor-pointer"
           onClick={() => setMinimized(!minimized)}
         >
           {minimized ? 'Expand' : 'Collapse'}

--- a/src/components/code/CodeGroup.tsx
+++ b/src/components/code/CodeGroup.tsx
@@ -52,7 +52,7 @@ export default function CodeGroup({
         <div ref={codeRef}>{children}</div>
         {/* {canExpand && ( */}
         <a
-          className="w-xs absolute bottom-0 left-2 right-0 block rounded-2xl bg-transparent p-0 text-sm font-medium text-white no-underline cursor-pointer"
+          className="w-xs absolute bottom-0 left-0 right-0 block rounded-2xl bg-transparent p-0 text-sm text-center font-medium text-white no-underline cursor-pointer"
           onClick={() => setMinimized(!minimized)}
         >
           {minimized ? 'Expand' : 'Collapse'}


### PR DESCRIPTION
## Description

Fixed the hover state for the collapse and expand button in the code view.

## Related Issue

Fixes #152 

## Proposed Changes

- Switched the button to an <a> tag
- Adds a nice hover effect
- Move it 1px to the left for proper spacing

## Screenshots

![fixxed](https://github.com/Ansub/SyntaxUI/assets/68947960/936b9505-1747-4d34-8caf-a758f0ca477c)

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

