### PR TITLE
fix: GradientFillButton using only Tailwind

### DIFF
--- a/src/app/docs/components/button/gradient-fill-button/page.mdx
+++ b/src/app/docs/components/button/gradient-fill-button/page.mdx
@@ -4,7 +4,7 @@ export const metadata = {
 }
 
 <BackButton href="/docs/components/button" />
-<ComponentPreview path="components/button/GradientFillButton" usingFramer />
+<ComponentPreview path="components/button/GradientFillButton" />
 
 
 

--- a/src/showcase/components/button/GradientFillButton.tsx
+++ b/src/showcase/components/button/GradientFillButton.tsx
@@ -1,40 +1,11 @@
-'use client'
-import { AnimatePresence, motion } from 'framer-motion'
-import { useState } from 'react'
-
 const GradientFillButton = () => {
-  const [isHovered, setIsHovered] = useState(false)
-
   return (
-    <motion.button
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-      initial={{
-        scale: 1,
-      }}
-      whileTap={{
-        scale: 0.95,
-      }}
-      className="relative overflow-hidden whitespace-nowrap rounded-md border-[1px] border-red-500/20 bg-red-100 px-5 py-1.5 text-xs font-medium text-red-500 transition-colors duration-500 hover:border-red-500 hover:text-white"
-    >
-      <span className="relative z-10">SyntaxUI</span>
-      <AnimatePresence>
-        {isHovered && (
-          <motion.span
-            initial={{ scaleY: 0, originY: 1 }}
-            animate={{ scaleY: 1 }}
-            exit={{ scaleY: 0 }}
-            transition={{
-              duration: 0.8,
-              type: 'spring',
-              stiffness: 150,
-              damping: 20,
-            }}
-            className="absolute inset-0 z-0 bg-gradient-to-t from-red-600 to-red-500"
-          />
-        )}
-      </AnimatePresence>
-    </motion.button>
+    <button className="group/button relative overflow-hidden rounded-md border border-red-500/20 bg-red-100 px-5 py-1.5 text-xs font-medium text-red-500 transition-all duration-150 hover:scale-105 hover:border-red-500 active:scale-95">
+      <span className="absolute bottom-0 left-0 z-0 h-0 w-full bg-gradient-to-t from-red-600 to-red-500 transition-all duration-500 group-hover/button:h-full" />
+      <span className="relative z-10 transition-all duration-500 group-hover/button:text-white">
+        SyntaxUI
+      </span>
+    </button>
   )
 }
 

--- a/src/showcase/components/button/GradientFillButton.tsx
+++ b/src/showcase/components/button/GradientFillButton.tsx
@@ -1,6 +1,6 @@
 const GradientFillButton = () => {
   return (
-    <button className="group/button relative overflow-hidden rounded-md border border-red-500/20 bg-red-100 px-5 py-1.5 text-xs font-medium text-red-500 transition-all duration-150 hover:scale-105 hover:border-red-500 active:scale-95">
+    <button className="group/button relative overflow-hidden rounded-md border border-red-500/20 bg-red-100 px-5 py-1.5 text-xs font-medium text-red-500 transition-all duration-150 hover:border-red-500 active:scale-95">
       <span className="absolute bottom-0 left-0 z-0 h-0 w-full bg-gradient-to-t from-red-600 to-red-500 transition-all duration-500 group-hover/button:h-full" />
       <span className="relative z-10 transition-all duration-500 group-hover/button:text-white">
         SyntaxUI


### PR DESCRIPTION
## Description

I re-implemented the `GradientFillButton` using only Tailwind

## Related Issue

Fixes #157 

## Proposed Changes

- changed `src/showcase/components/button/GradientFillButton.tsx` to only use tailwind

## Screenshots

https://github.com/Ansub/SyntaxUI/assets/16091805/50a984a8-974b-410e-9562-36ab86387218

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)
