### PR TITLE
Fix: footer positioning issue

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -28,7 +28,7 @@ export function Layout({
             <Navigation className="hidden lg:mt-[4rem] lg:block" />
           </div>
         </motion.header>
-        <div className="relative flex h-full flex-col px-4 pt-14 sm:px-6 lg:px-8">
+        <div className="relative flex max-h-full min-h-screen flex-col px-4 pt-14 sm:px-6 lg:px-8">
           <main className="flex-auto">{children}</main>
           <Footer />
         </div>


### PR DESCRIPTION
## Description

This PR addresses a bug where the footer incorrectly appeared at the top instead of the bottom on components not filling the entire viewport. By adding `min and max height` the footer now consistently stays at the bottom as intended, improving overall usability.

## Related Issue

Fixes #159 

## Proposed Changes

- Added `min` and `max height` to fix this issue

## Screenshots

<img width="1435" alt="Screenshot 2024-05-07 at 4 15 24 PM" src="https://github.com/Ansub/SyntaxUI/assets/92677078/9f62db14-93f1-4452-99ac-b14a94a92fa1">


## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

## Additional Context

Please provide any additional context or information about the pull request here.
