### PR TITLE
fix: BorderGlowButton only Tailwind

### DIFF
--- a/src/app/(docs)/components/button/border-glow-button/page.mdx
+++ b/src/app/(docs)/components/button/border-glow-button/page.mdx
@@ -5,4 +5,4 @@ export const metadata = {
 
 <BackButton href="/components/button" />
 
-<ComponentPreview path="components/button/BorderGlowButton" usingFramer/>
+<ComponentPreview path="components/button/BorderGlowButton" />

--- a/src/showcase/components/button/BorderGlowButton.tsx
+++ b/src/showcase/components/button/BorderGlowButton.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import { useEffect, useRef, useState } from 'react'
 
 const BorderGlowButton = () => {
@@ -22,16 +21,9 @@ const BorderGlowButton = () => {
   }, [])
 
   return (
-    <motion.button
-      className="relative overflow-hidden rounded-lg bg-[#e5e7eb]"
+    <button
+      className="relative overflow-hidden rounded-lg bg-[#e5e7eb] transform active:scale-95"
       ref={ref}
-      initial={{ scale: 1 }}
-      whileTap={{ scale: 0.95 }}
-      transition={{
-        type: 'spring',
-        stiffness: 500,
-        damping: 20,
-      }}
     >
       <span
         className={`absolute z-0 h-28 w-28 -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(#fb3b53_0%,transparent_70%)] `}
@@ -45,7 +37,7 @@ const BorderGlowButton = () => {
       <div className="relative z-10 m-[1px] rounded-[calc(0.5rem-1px)] bg-white/90  px-4 py-1 text-xs text-[#fb3b53] backdrop-blur-sm">
         SyntaxUI
       </div>
-    </motion.button>
+    </button>
   )
 }
 

--- a/src/showcase/components/button/BorderGlowButton.tsx
+++ b/src/showcase/components/button/BorderGlowButton.tsx
@@ -22,7 +22,7 @@ const BorderGlowButton = () => {
 
   return (
     <button
-      className="relative overflow-hidden rounded-lg bg-[#e5e7eb] transform active:scale-95"
+      className="relative overflow-hidden rounded-lg bg-[#e5e7eb] transform transition-transform ease-in-out active:scale-90"
       ref={ref}
     >
       <span


### PR DESCRIPTION
## Description

fixed `BorderGlowButton` using only Tailwind .

## Related Issue

Fixes #176 

## Proposed Changes

- changed `src/showcase/components/button/BorderGlowButton.tsx` to only use tailwind
- Change : remove note  This component requires Framer Motion from `src/app/(docs)/components/button/border-glow-button/page.mdx`


## Screenshots


![issus176](https://github.com/Ansub/SyntaxUI/assets/82626103/e55360ac-9538-46eb-bbac-3a61ddf1d79d)

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

## Additional Context
Please provide any additional context or information about the pull request here.
