### PR TITLE
Updated Icon/Simple toggles

### DIFF
--- a/src/showcase/components/toggle/IconToggle.tsx
+++ b/src/showcase/components/toggle/IconToggle.tsx
@@ -28,7 +28,7 @@ const IconToggle = ({
       }}
     >
       <motion.div
-        className="flex aspect-square size-[19px] items-center justify-center rounded-full bg-white shadow-lg"
+        className="flex aspect-square h-full items-center justify-center rounded-full bg-white shadow-lg"
         layout
         transition={{ duration: 0.2 }}
         animate={{

--- a/src/showcase/components/toggle/IconToggle.tsx
+++ b/src/showcase/components/toggle/IconToggle.tsx
@@ -19,20 +19,20 @@ const IconToggle = ({
   }
 
   return (
-    <motion.button
-      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[2px]`}
+    <button
+      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[3px] justify-start duration-200`}
       onClick={handleToggle}
-      animate={{ backgroundColor: toggled ? '#fb3a5d' : '#24252d50' }}
-      transition={{ duration: 0.2 }}
+      style={{
+        backgroundColor: toggled ? '#fb3a5d' : '#24252d50',
+        justifyContent: toggled ? 'end' : 'start',
+      }}
     >
-      <motion.span
-        className="flex items-center justify-center rounded-full bg-white shadow-lg"
+      <motion.div
+        className="flex aspect-square size-[19px] items-center justify-center rounded-full bg-white shadow-lg"
         layout
         transition={{ duration: 0.2 }}
-        style={{
-          width: toggled ? '19px' : '16px',
-          height: toggled ? '19px' : '16px',
-          marginLeft: toggled ? '20px' : '2px',
+        animate={{
+          scale: toggled ? 1 : 0.9,
         }}
       >
         <AnimatePresence mode="wait">
@@ -40,7 +40,7 @@ const IconToggle = ({
             <motion.div
               key="check"
               initial={{ opacity: 0, scale: 0.5 }}
-              animate={{ opacity: 1, rotate: 0, scale: 1 }}
+              animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.5 }}
               transition={{ duration: 0.1 }}
             >
@@ -50,7 +50,7 @@ const IconToggle = ({
             <motion.div
               key="x"
               initial={{ opacity: 0, scale: 0.5 }}
-              animate={{ opacity: 1, rotate: 0, scale: 1 }}
+              animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.5 }}
               transition={{ duration: 0.1 }}
             >
@@ -58,8 +58,8 @@ const IconToggle = ({
             </motion.div>
           )}
         </AnimatePresence>
-      </motion.span>
-    </motion.button>
+      </motion.div>
+    </button>
   )
 }
 

--- a/src/showcase/components/toggle/SimpleToggle.tsx
+++ b/src/showcase/components/toggle/SimpleToggle.tsx
@@ -18,23 +18,23 @@ const SimpleToggle = ({
   }
 
   return (
-    <motion.button
-      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[2px]`}
+    <button
+      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[3px] duration-200`}
       onClick={handleToggle}
-      animate={{ backgroundColor: toggled ? '#fb3a5d' : '#24252d50' }}
-      transition={{ duration: 0.2 }}
+      style={{
+        backgroundColor: toggled ? '#fb3a5d' : '#24252d50',
+        justifyContent: toggled ? 'end' : 'start',
+      }}
     >
       <motion.span
-        className="rounded-full bg-white shadow-lg"
+        className="size-[19px] rounded-full bg-white shadow-lg"
         layout
         transition={{ duration: 0.2 }}
-        style={{
-          width: toggled ? '19px' : '16px',
-          height: toggled ? '19px' : '16px',
-          marginLeft: toggled ? '20px' : '2px',
+        animate={{
+          scale: toggled ? 1 : 0.8,
         }}
       />
-    </motion.button>
+    </button>
   )
 }
 

--- a/src/showcase/components/toggle/SimpleToggle.tsx
+++ b/src/showcase/components/toggle/SimpleToggle.tsx
@@ -19,7 +19,7 @@ const SimpleToggle = ({
 
   return (
     <button
-      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[3px] duration-200`}
+      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[4px] duration-200`}
       onClick={handleToggle}
       style={{
         backgroundColor: toggled ? '#fb3a5d' : '#24252d50',
@@ -27,7 +27,7 @@ const SimpleToggle = ({
       }}
     >
       <motion.span
-        className="size-[19px] rounded-full bg-white shadow-lg"
+        className="h-full aspect-square rounded-full bg-white shadow-lg"
         layout
         transition={{ duration: 0.2 }}
         animate={{


### PR DESCRIPTION
The Framer Motion Layout has been implemented correctly, based on my knowledge.

The current usage:
- The parent component is a non-motion component with a non-animatable style property (in this case, Justify-content) that switches between 'end' and 'start'.
- The child component is a motion component with a layout set to true.


**Please note that animating x from 0 to 100% is more performant and reliable than manipulating the DOM. However, I updated the code based on @Ansub 's suggestion.**


File modified:
> src/showcase/components/toggle/IconToggle.tsx
> src/showcase/components/toggle/SimpleToggle.tsx
