### PR TITLE
Fixed :  images : {domain :[..]} to images: remotePatterns

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,7 +32,12 @@ const nextConfig = {
     ]
   },
   images: {
-    domains: ['ansubkhan.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'ansubkhan.com',
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Description

change images : {domain :["//"]} to images: remotePatterns
     [Refer](https://nextjs.org/docs/messages/next-image-unconfigured-host) 

Because `images:domain `is deprecated

## Related Issue


Fixes #181 

## Proposed Changes

- Change file ` next.config.mjs`

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the credits.md file (if applicable)

