### PR TITLE
fix: added fade to logo cloud

### DIFF
--- a/src/showcase/components/logo-cloud/AnimatedLogoCloud.tsx
+++ b/src/showcase/components/logo-cloud/AnimatedLogoCloud.tsx
@@ -50,9 +50,15 @@ const logos = [
 
 const AnimatedLogoCloud = () => {
   return (
-    <div className="py-12">
-      <div className="mx-auto max-w-4xl px-4 md:px-8">
-        <div className="group relative mt-6 flex gap-6 overflow-hidden p-2">
+    <div className="w-full py-12">
+      <div className="mx-auto w-full px-4 md:px-8">
+        <div
+          className="group relative mt-6 flex gap-6 overflow-hidden p-2"
+          style={{
+            maskImage:
+              'linear-gradient(to left, transparent 0%, black 20%, black 80%, transparent 90%)',
+          }}
+        >
           {Array(5)
             .fill(null)
             .map((index) => (

--- a/src/showcase/components/logo-cloud/AnimatedLogoCloud.tsx
+++ b/src/showcase/components/logo-cloud/AnimatedLogoCloud.tsx
@@ -56,7 +56,7 @@ const AnimatedLogoCloud = () => {
           className="group relative mt-6 flex gap-6 overflow-hidden p-2"
           style={{
             maskImage:
-              'linear-gradient(to left, transparent 0%, black 20%, black 80%, transparent 90%)',
+              'linear-gradient(to left, transparent 0%, black 20%, black 80%, transparent 95%)',
           }}
         >
           {Array(5)


### PR DESCRIPTION


## Description

- added fade effect on sides of LogoCloud
- changed width to 100% so the effect works on multiple sizes

## Related Issue

Fixes #192 

## Proposed Changes

- I used a `linear-gradient` to mask out the `AnimatedLogoCloud` on the left and right sides to add a fade effect.
- I added `w-full` to the containers to make the sizing work so that the `linear-gradient` applies to the full width instead of applying to hidden sections (caused by `overflow-hidden`) 

## Screenshots

https://github.com/Ansub/SyntaxUI/assets/16091805/59c4183f-9d9a-421d-a698-1742119228cf

## Checklist

Please check the boxes that apply:

- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

## Additional Context

I chose to use `maskImage` instead of using `span`s with a basic gradient so that it will work on any background color.
