### PR TITLE
fix: Removed Framer Motion from Simple Toggle

### DIFF
--- a/src/app/(docs)/components/toggle/simple-toggle/page.mdx
+++ b/src/app/(docs)/components/toggle/simple-toggle/page.mdx
@@ -5,4 +5,4 @@ export const metadata = {
 
 <BackButton href="/components/toggle" />
 
-<ComponentPreview path="components/toggle/SimpleToggle" usingFramer/>
+<ComponentPreview path="components/toggle/SimpleToggle" />

--- a/src/showcase/components/toggle/SimpleToggle.tsx
+++ b/src/showcase/components/toggle/SimpleToggle.tsx
@@ -1,6 +1,11 @@
 'use client'
 import React, { useState } from 'react'
-import { motion } from 'framer-motion'
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
 
 const SimpleToggle = ({
   onToggle,
@@ -19,20 +24,19 @@ const SimpleToggle = ({
 
   return (
     <button
-      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[4px] duration-200`}
+      className={`relative h-7 w-12 cursor-pointer rounded-full duration-200`}
       onClick={handleToggle}
       style={{
         backgroundColor: toggled ? '#fb3a5d' : '#24252d50',
-        justifyContent: toggled ? 'end' : 'start',
       }}
     >
-      <motion.span
-        className="h-full aspect-square rounded-full bg-white shadow-lg"
-        layout
-        transition={{ duration: 0.2 }}
-        animate={{
-          scale: toggled ? 1 : 0.8,
-        }}
+      <span
+        className={cn(
+          `absolute left-0 top-0 rounded-full bg-white shadow-lg transition-all duration-200`,
+          toggled ? 'translate-x-full transform' : 'translate-x-0 transform',
+          toggled ? 'h-5 w-5' : 'h-4 w-4',
+          toggled ? 'm-1' : 'm-1.5',
+        )}
       />
     </button>
   )

--- a/src/showcase/components/toggle/SimpleToggle.tsx
+++ b/src/showcase/components/toggle/SimpleToggle.tsx
@@ -1,10 +1,8 @@
 'use client'
 import React, { useState } from 'react'
-import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(...classNames: string[]) {
+  return classNames.filter(Boolean).join(' ')
 }
 
 const SimpleToggle = ({


### PR DESCRIPTION
## Description

I removed the Framer Motion dependency from the Simple Toggle Component

## Related Issue

Fixes #200 

## Proposed Changes

- modified `src/showcase/components/toggle/SimpleToggle.tsx`
  - removed framer motion references
  - added local version of the `cn` function to the file so that it is visible in the code preview
  - changed from arbitrary pixel sizes to using build in tailwind sizes (width, height, and padding)
  - implemented same transition using raw tailwind instead of tailwind + framer motion
- modified `src/app/(docs)/components/toggle/simple-toggle/page.mdx`
  - removed `usingFramer` tag from docs page

## Screenshots

If applicable, please include screenshots or GIFs to demonstrate the changes made.

## Checklist

Please check the boxes that apply:

- [x] I have rebased my branch on top of the latest `main` branch.
- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

